### PR TITLE
Fix for Unused options Parameter in ProcessBuilder Creation

### DIFF
--- a/src/main/java/com/julienviet/childprocess/Process.java
+++ b/src/main/java/com/julienviet/childprocess/Process.java
@@ -79,7 +79,7 @@ public interface Process {
    * @return the created child process
    */
   static ProcessBuilder create(Vertx vertx, String command, ProcessOptions options) {
-    return create(vertx, command, Collections.emptyList(), new ProcessOptions());
+    return create(vertx, command, Collections.emptyList(), options);
   }
 
   /**


### PR DESCRIPTION
Hello,

I've identified a bug in the create method of the ProcessBuilder class. The method signature suggests that it should use the ProcessOptions options parameter provided by the caller. However, in the current implementation, the method disregards this parameter and instead creates a new ProcessOptions object. This behavior could lead to unexpected issues, as any custom configurations passed through the options parameter are not being utilized.

The problematic code snippet is as follows:

```
static ProcessBuilder create(Vertx vertx, String command, ProcessOptions options) {
    return create(vertx, command, Collections.emptyList(), new ProcessOptions());
}
```

To resolve this, I propose modifying the method to use the provided options parameter instead of creating a new ProcessOptions object. The corrected line of code should be:


```
return create(vertx, command, Collections.emptyList(), options);
```
This change ensures that the method respects the caller's configurations passed through the options parameter, adhering to the expected functionality.

I have attached the changes in this pull request for review.

Thank you for considering this fix.

Best regards,
刘睿